### PR TITLE
Update conference schedule interval to 10 minutes

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -254,7 +254,7 @@ class Conference < ActiveRecord::Base
   end
 
   def schedule_interval
-    0.25
+    100.to_f / 6 # a sixth of an hour is 10 minutes
   end
 
   def validate_workshop_blocks


### PR DESCRIPTION
Goal: Change the length of scheduling intervals on bikebike.org to 10 minute increments to support the schedule for Bike!Bike! Everywhere (workshops with 10 minute breaks inbetween).

To achieve this I've updated the interval value within the `schedule_interval` method of the conference model in the collectives_core gem. But it's possible it:

- Can be overridden on a per conference basis
- Won't display nicely because of floating point math
- has a different interval configuration on frontend vs. backend.

Either way this is a first stab done by some initial poking around. I'll follow up tomorrow if I learn more.